### PR TITLE
API path to return policy text, page count and url to policy pdf

### DIFF
--- a/api.py
+++ b/api.py
@@ -130,10 +130,16 @@ def get_policy_text_by_page(
     doc_id = f"{policy_id}_page{page}"
 
     try:
+        # Get the page text for the given document and page
         es_doc = es.get_doc_by_id(doc_id)
         page_text = es_doc["_source"]["text"]
+
+        # Get the total page count for the document
+        page_count = es.get_page_count_for_doc(policy_id)
         return {
-            "documentMetadata": {},
+            "documentMetadata": {
+                "pageCount": page_count
+            },
             "pageText": page_text,
         }
 

--- a/policy_search/pipeline/elasticsearch.py
+++ b/policy_search/pipeline/elasticsearch.py
@@ -200,6 +200,35 @@ class ElasticSearchIndex(BaseCallback):
             body=es_query,
             index=self.index_name
         )
+
+    def get_page_count_for_doc(
+        self,
+        policy_id: int
+    ) -> int:
+        """Return the total number of pages in the elastic search index for a given document
+        """
+
+        es_query = {
+            "query": {
+                "match": {
+                    "policy_id": policy_id
+                }
+            },
+            "size": 0,
+            "aggs": {
+                "page_count": {"max": {"field": "page_number"}}
+            }
+        }
+
+        query_result = self.es.search(
+            body=es_query,
+            index=self.index_name
+        )
+
+        doc_page_count = query_result['aggregations']['page_count']['value']
+
+        return doc_page_count
+
             
     def _create_page_dicts_from_doc(
         self,


### PR DESCRIPTION
@kdutia originally implemented the ```policies/{id}/text/?pageNumber={page}``` endpoint to return the text for a given page. I have added:

- Total page count so that front end is aware when end of text has been reached during navigation

In order to keep things simple for the prototype, decided to use the existing CCLW urls for source pdf document for now rather than load into s3 bucket.