### PR TITLE
Add Python formatting and linting using pre-commit

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+ignore = E203

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+-   repo: https://github.com/ambv/black
+    rev: 21.8b0
+    hooks:
+    - id: black
+      language_version: python3
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 4.0.0
+    hooks:
+    - id: flake8
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.1.0 
+    hooks:
+    -   id: check-json
+    -   id: detect-aws-credentials
+        args: [--allow-missing-credentials ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ COPY . ./
 RUN poetry config virtualenvs.create false
 RUN poetry install
 RUN poetry run python -m spacy download en_core_web_sm
+RUN poetry run pre-commit install --install-hooks
 
 # Make sure script has execute permissions
 RUN chmod +x ./scripts/start_api.sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ elasticsearch = "*"
 
 [tool.poetry.dev-dependencies]
 jupyterlab = "^3.1.14"
+pre-commit = "^2.15.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
* Added `black` and `flake8` as pre-commit hooks, with the [appropriate flake8 config for it to not clash with black](https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#flake8). 
* Also added `check-json` and `check-aws-credentials`. These are just checkers - they will prompt you to modify any files rather than changing them (unlike `black`).
* Added pre-commit to poetry environment, and `pre-commit install` command to Dockerfile - which installs the hooks themselves
* Tested - this commit was checked with the hooks 😀 (although no Python)

Closes https://github.com/climatepolicyradar/cpr-issues/issues/101



