### PR TITLE
Add logging and change parse_pdfs prints to use logger (#100)

### DIFF
--- a/parse_pdfs.py
+++ b/parse_pdfs.py
@@ -9,6 +9,7 @@ from typing import List, AnyStr
 
 from policy_search.pipeline.fetch import CSVDocumentSourceFetcher
 from policy_search.pipeline.preprocess import clean_text
+from policy_search.logging import get_logger
 
 import fitz
 import spacy
@@ -16,6 +17,7 @@ import numpy as np
 from sortedcontainers import SortedKeyList
 import yaml
 
+logger = get_logger(__name__)
 
 MIN_WORDS_SPAN = 0
 MIN_WORDS_LINE = 2
@@ -284,7 +286,7 @@ def main(csv_filename: Path, data_path: Path):
 
     # Process all pdfs
     #pdf_extractor.process_pdfs(csv_filename)
-    print(doc_structure)
+    logger.debug(doc_structure)
     
 
 if __name__ == '__main__':

--- a/policy_search/logging.py
+++ b/policy_search/logging.py
@@ -1,0 +1,13 @@
+import logging
+import sys
+
+
+def get_logger(name):
+    logger = logging.getLogger(name)
+    logger.setLevel(logging.DEBUG)
+    stream_handler = logging.StreamHandler(sys.stdout)
+    format_string = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    formatter = logging.Formatter(format_string)
+    stream_handler.setFormatter(formatter)
+    logger.addHandler(stream_handler)
+    return logger


### PR DESCRIPTION
* Added a `get_logger()` method in `policy_search.logging`. 
* Changed the `print()` functions in `parse_pdfs` to use the logger.

**To use:**

``` py
from policy_search.logging import get_logger
logger = get_logger(__name__)

# logger.info / logger.debug / logger.warning / logger.error
```

I suggest that we use:
* `logger.info` for business-friendly logs
* `logger.debug` for more technical logs
* `logger.warning` and `logger.error` as appropriate

**Example:**

I added the following lines of code to `api.get_geographies`:

``` py
logger.debug("geography!")
logger.info("geography!!")
```

which produced the following logs when accessing the `/geographies` route:

``` log
cpr-policy-api    | 2021-10-12 09:40:47,666 - api - DEBUG - geography!
cpr-policy-api    | 2021-10-12 09:40:47,666 - api - INFO - geography!!
cpr-policy-api    | INFO:     172.18.0.1:63442 - "GET /geographies HTTP/1.1" 200 OK
```

Closes https://github.com/climatepolicyradar/cpr-issues/issues/100

