### PR TITLE
Bug 118 broken geographies filtering

### DIFF
--- a/api.py
+++ b/api.py
@@ -14,15 +14,15 @@ from temp_geographies.load_geographies_data import Geography, load_geographies_d
 from schema.schema_helpers import get_schema_dict_from_path, SchemaTopLevel
 
 
-POLICIES_TABLE = 'Policies'
+POLICIES_TABLE = "Policies"
 
-dynamodb_host = os.environ.get('dynamodb_host', 'localhost')
-dynamodb_port = os.environ.get('dynamodb_port', '8000')
-dynamodb_url = f'http://{dynamodb_host}:{dynamodb_port}'
+dynamodb_host = os.environ.get("dynamodb_host", "localhost")
+dynamodb_port = os.environ.get("dynamodb_port", "8000")
+dynamodb_url = f"http://{dynamodb_host}:{dynamodb_port}"
 
-policy_table = PolicyDynamoDBTable(dynamodb_url, 'policyId')
+policy_table = PolicyDynamoDBTable(dynamodb_url, "policyId")
 
-elastic_host = os.environ.get('elasticsearch_cluster', 'localhost:9200')
+elastic_host = os.environ.get("elasticsearch_cluster", "localhost:9200")
 es = ElasticSearchIndex(es_url=elastic_host)
 
 app = FastAPI()
@@ -31,43 +31,42 @@ app = FastAPI()
 # Note: this is likely to need changing for deployment
 app.add_middleware(
     CORSMiddleware,
-    allow_origin_regex='https?:\/\/localhost:?[0-9]*',
+    allow_origin_regex=r"https?://localhost:?[0-9]*",
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
 )
 
 
-@app.get('/policies/', response_model=PolicyList)
+@app.get("/policies/", response_model=PolicyList)
 async def read_policies(
-    start: int=0,
-    limit: int=100,
+    start: int = 0,
+    limit: int = 100,
 ):
     """Return all policies"""
 
     return policy_table.scan(start, limit)
 
-@app.get('/policies/search/', response_model=PolicySearchResponse)
+
+@app.get("/policies/search/", response_model=PolicySearchResponse)
 def search_policies(
-    query: str, 
-    start: Optional[int]=0, 
-    limit: Optional[int]=100,
+    query: str,
+    start: Optional[int] = 0,
+    limit: Optional[int] = 100,
     geography: Optional[List[str]] = Query(None),
 ):
     "Search for policies given a specified query"
 
     if geography:
-        kwd_filters = {
-            "country_code.keyword": geography
-        }
+        kwd_filters = {"country_code.keyword": geography}
     else:
         kwd_filters = None
 
-    # There is no option to offset results for terms aggregation queries, so instead we 
+    # There is no option to offset results for terms aggregation queries, so instead we
     # get the first `start+limit` results and offset them by `start`.
     search_result = es.search(
         query,
-        limit=start+limit,
+        limit=start + limit,
         keyword_filters=kwd_filters,
     )
 
@@ -75,7 +74,7 @@ def search_policies(
 
     query_results_by_doc = []
 
-    for result in results_by_doc[start : start+limit]:
+    for result in results_by_doc[start : start + limit]:
         hits_by_page = result["top_passage_hits"]["hits"]["hits"]
         # num_pages_with_hit = result["doc_count"]
         policy_id = result["key"]
@@ -89,31 +88,35 @@ def search_policies(
         for hit in hits_by_page:
             if "highlight" in hit:
                 # Only return a page if there is at least one text match in the page
-                document_response.append({
-                    "pageNumber": hit["_source"]["page_number"],
-                    "text": hit["highlight"]["text"],
-                })
+                document_response.append(
+                    {
+                        "pageNumber": hit["_source"]["page_number"],
+                        "text": hit["highlight"]["text"],
+                    }
+                )
 
-        query_results_by_doc.append(
-            {   
-                "policyId": policy_id,
-                "policyName": policy_name,
-                "countryCode": policy_country_code,
-                "sourceName": policy_source_name,
-                "resultsByPage": document_response,
-            }
-        )
+        if document_response:
+            query_results_by_doc.append(
+                {
+                    "policyId": policy_id,
+                    "policyName": policy_name,
+                    "countryCode": policy_country_code,
+                    "sourceName": policy_source_name,
+                    "resultsByPage": document_response,
+                }
+            )
 
     response = {
         "metadata": {
-            "numDocsReturned": len(results_by_doc[start : start+limit]),
+            "numDocsReturned": len(results_by_doc[start : start + limit]),
         },
         "resultsByDocument": query_results_by_doc,
     }
 
     return response
 
-@app.get('/policies/{policy_id}/', response_model=Policy)
+
+@app.get("/policies/{policy_id}/", response_model=Policy)
 def read_policy(
     policy_id: int,
 ):
@@ -121,7 +124,8 @@ def read_policy(
 
     return policy_table.get_document(policy_id)
 
-@app.get('/policies/{policy_id}/text/', response_model=PolicyPageText)
+
+@app.get("/policies/{policy_id}/text/", response_model=PolicyPageText)
 def get_policy_text_by_page(
     policy_id: int,
     page: int,
@@ -138,18 +142,19 @@ def get_policy_text_by_page(
         # Get the total page count for the document
         page_count = es.get_page_count_for_doc(policy_id)
         return {
-            "documentMetadata": {
-                "pageCount": page_count
-            },
+            "documentMetadata": {"pageCount": page_count},
             "pageText": page_text,
         }
 
     except ElasticNotFoundError:
-        raise HTTPException(status_code=404, detail="Policy document or page within it not found")
+        raise HTTPException(
+            status_code=404, detail="Policy document or page within it not found"
+        )
+
 
 @app.get("/geographies", response_model=List[Geography])
 def get_geographies():
-    """Get information on geographies. Currently from a static CSV.""" 
+    """Get information on geographies. Currently from a static CSV."""
 
     GEOGRAPHIES_CSV_PATH = Path("./temp_geographies/geographies.csv")
 
@@ -160,10 +165,11 @@ def get_geographies():
 def get_instruments():
     return get_schema_dict_from_path("./schema/instruments.yml")
 
+
 @app.get("/sectors", response_model=List[SchemaTopLevel])
 def get_sectors():
     return get_schema_dict_from_path("./schema/sectors.yml")
 
+
 if __name__ == "__main__":
     uvicorn.run(app, host="0.0.0.0", port=8001)
-

--- a/policy_search/pipeline/elasticsearch.py
+++ b/policy_search/pipeline/elasticsearch.py
@@ -2,12 +2,10 @@
 """
 
 
-from typing import List, Optional, Generator
+from typing import List, Optional
 
 from elasticsearch import Elasticsearch, helpers
 
-from .fetch import DocumentSourceFetcher
-from ..parser.pdf_parser import PDFParser
 from .models.policy import Policy
 from .base import BaseCallback
 
@@ -19,21 +17,21 @@ class ElasticSearchIndex(BaseCallback):
         es_user: Optional[str] = None,
         es_password: Optional[str] = None,
         es_connector_kwargs: dict = {},
-    ):  
-        super().__init__('elasticsearch')
-        self.index_name = 'policies'
+    ):
+        super().__init__("elasticsearch")
+        self.index_name = "policies"
 
         self.es_url = es_url
         self.es_login = (es_user, es_password)
         self.es_connector_kwargs = es_connector_kwargs
 
         self._connect_to_elasticsearch()
-        
+
         self._docs_to_load = []
 
     def _connect_to_elasticsearch(
         self,
-        ):
+    ):
 
         if self.es_url:
             if all(self.es_login):
@@ -42,18 +40,18 @@ class ElasticSearchIndex(BaseCallback):
                 )
             else:
                 self.es = Elasticsearch([self.es_url], **self.es_connector_kwargs)
-            
+
         else:
             self.es = Elasticsearch(**self.es_connector_kwargs)
 
     def _is_connected_to_elasticsearch(self) -> bool:
         return self.es.ping()
-                        
+
     def delete_and_create_index(self):
         """
         Creates index. Deletes any existing index of the same name first.
         """
-        
+
         self.es.indices.delete(index=self.index_name, ignore=[400, 404])
         self.es.indices.create(index=self.index_name)
 
@@ -72,7 +70,7 @@ class ElasticSearchIndex(BaseCallback):
         Load documents in the in-memory store into Elasticsearch.
         """
 
-        # We check the connection here in case there have been any issues since 
+        # We check the connection here in case there have been any issues since
         # creation of the instance of this class.
         if not self._is_connected_to_elasticsearch():
             self._connect_to_elasticsearch()
@@ -83,16 +81,16 @@ class ElasticSearchIndex(BaseCallback):
             client=self.es,
             index=self.index_name,
             actions=iter(self._docs_to_load),
-            raise_on_error=True
+            raise_on_error=True,
         )
-        
+
         successes = 0
         errs = []
-        
+
         for ok, action in bulk_loader:
             if not ok:
                 errs.append(action)
-                
+
             successes += ok
 
     def get_doc_by_id(
@@ -102,7 +100,7 @@ class ElasticSearchIndex(BaseCallback):
         """Get document by its '_id' field."""
 
         return self.es.get(
-            index=self.index_name, 
+            index=self.index_name,
             id=_id,
         )
 
@@ -112,71 +110,52 @@ class ElasticSearchIndex(BaseCallback):
         limit: Optional[int] = None,
         # start: Optional[int] = 0,
         keyword_filters: Optional[dict] = None,
-        max_pages_per_doc: Optional[int] = 10
+        max_pages_per_doc: Optional[int] = 10,
     ) -> List[dict]:
         """
-        Search for `query`, starting at result `start` and returning up to `limit` results.
-        
-        `keyword_filters` should be a dictionary, where each key is the field to be filtered, and each value is a list of strings to filter on. In
-        Elasticsearch, keywords are datatypes that are only searchable by their exact value, therefore are useful for filtering.
+        Search for `query`, starting at result `start` and returning up to `limit`
+        results.
+
+        `keyword_filters` should be a dictionary, where each key is the field to be
+        filtered, and each value is a list of strings to filter on. In Elasticsearch,
+        keywords are datatypes that are only searchable by their exact value, therefore
+        are useful for filtering.
 
         If `limit` is not provided, the index default will be used.
-        If `max_pages_per_doc` is not provided, the top 10 pages for each document will be returned.
+        If `max_pages_per_doc` is not provided, the top 10 pages for each document will
+        be returned.
         """
 
         fields_to_search = ["text", "policy_name"]
 
         es_query = {
-            "query": { 
+            "query": {
                 "bool": {
                     "should": [
-                        {
-                            "multi_match": {
-                                "query": query,
-                                "fields": fields_to_search
-                            }
-                        }
+                        {"multi_match": {"query": query, "fields": fields_to_search}}
                     ],
                 }
             },
-            "highlight": {
-                "fields": {
-                    "text": {
-                        "number_of_fragments": 0
-                    }
-                } 
-            },
+            "highlight": {"fields": {"text": {"number_of_fragments": 0}}},
             "aggs": {
                 "top_docs": {
                     "terms": {
                         "field": "policy_id",
-                        "order": {
-                            "top_hit": "desc"
-                        },
+                        "order": {"top_hit": "desc"},
                     },
                     "aggs": {
                         "top_passage_hits": {
                             "top_hits": {
                                 "highlight": {
-                                    "fields": {
-                                        "text": {
-                                            "number_of_fragments": 0
-                                        }
-                                    } 
+                                    "fields": {"text": {"number_of_fragments": 0}}
                                 },
                                 "size": max_pages_per_doc,
                             }
                         },
-                        "top_hit" : {
-                            "max": {
-                                "script": {
-                                "source": "_score"
-                                }
-                            }
-                        }
-                    }
+                        "top_hit": {"max": {"script": {"source": "_score"}}},
+                    },
                 }
-            }
+            },
         }
 
         if limit:
@@ -184,89 +163,65 @@ class ElasticSearchIndex(BaseCallback):
 
         if keyword_filters:
             terms_clauses = []
-            
+
             for field, values in keyword_filters.items():
-                terms_clauses.append(
-                    {
-                        "terms": {
-                            field: values
-                        }
-                    }
-                )
+                terms_clauses.append({"terms": {field: values}})
 
-            es_query["query"]["bool"]["must"] = terms_clauses
+            es_query["query"]["bool"]["filter"] = terms_clauses
 
-        return self.es.search(
-            body=es_query,
-            index=self.index_name
-        )
+        return self.es.search(body=es_query, index=self.index_name)
 
-    def get_page_count_for_doc(
-        self,
-        policy_id: int
-    ) -> int:
-        """Return the total number of pages in the elastic search index for a given document
+    def get_page_count_for_doc(self, policy_id: int) -> int:
+        """
+        Return the total number of pages in the elasticsearch index for a given
+        document
         """
 
         es_query = {
-            "query": {
-                "match": {
-                    "policy_id": policy_id
-                }
-            },
+            "query": {"match": {"policy_id": policy_id}},
             "size": 0,
-            "aggs": {
-                "page_count": {"max": {"field": "page_number"}}
-            }
+            "aggs": {"page_count": {"max": {"field": "page_number"}}},
         }
 
-        query_result = self.es.search(
-            body=es_query,
-            index=self.index_name
-        )
+        query_result = self.es.search(body=es_query, index=self.index_name)
 
-        doc_page_count = query_result['aggregations']['page_count']['value']
+        doc_page_count = query_result["aggregations"]["page_count"]["value"]
 
         return doc_page_count
 
-            
     def _create_page_dicts_from_doc(
-        self,
-        doc: Policy,
-        doc_structure: dict
+        self, doc: Policy, doc_structure: dict
     ) -> List[dict]:
         """
         For use with `doc_source_fetcher.get_text_by_page`
         """
-        
+
         page_docs = []
 
         for page_num, page_text in doc_structure.items():
-            page_docs.append({
-                "_id": f"{doc.policy_id}_page{page_num}",
-                'text': page_text,
-                'policy_id': doc.policy_id,
-                'policy_name': doc.policy_name,
-                'page_number': page_num,
-                'country_code': doc.country_code,     
-                'source_name': doc.source_name,
-            })
+            page_docs.append(
+                {
+                    "_id": f"{doc.policy_id}_page{page_num}",
+                    "text": page_text,
+                    "policy_id": doc.policy_id,
+                    "policy_name": doc.policy_name,
+                    "page_number": page_num,
+                    "country_code": doc.country_code,
+                    "source_name": doc.source_name,
+                }
+            )
 
         return page_docs
 
-    def _create_doc_dict(
-        self,
-        doc: Policy,
-        doc_structure: str
-    ) -> dict:
+    def _create_doc_dict(self, doc: Policy, doc_structure: str) -> dict:
         """
         For use with `doc_source_fetcher.get_text`
         """
 
         return {
-            'text': doc_structure,
-            'policy_id': doc.policy_id,
-            'policy_name': doc.policy_name,
-            'country_code': doc.country_code,     
-            'source_name': doc.source_name,
+            "text": doc_structure,
+            "policy_id": doc.policy_id,
+            "policy_name": doc.policy_name,
+            "country_code": doc.country_code,
+            "source_name": doc.source_name,
         }


### PR DESCRIPTION
* Changed the Elasticsearch search type when filtering by an attribute from `must` to `filter` ([ref](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-filter-context.html))
* Search API no longer shows documents with no relevant passages

NOTE: files were also auto-formatted, hence the larger changes than described above.

Closes https://github.com/climatepolicyradar/cpr-issues/issues/118