### PR TITLE
feat 110: improvements to representation of a page of parsed text

### DIFF
--- a/app/src/pages/policy/[pid].tsx
+++ b/app/src/pages/policy/[pid].tsx
@@ -146,7 +146,7 @@ const Policy = () => {
             <button
               onClick={() => { changePageNumber('prev') }}
               style={{height: '36px'}}
-              className={`bg-black text-white px-4 rounded-l-lg border-r border-white focus:outline-black hover:bg-gray-700 transition duration-300 ${parseInt(page) === 0 ? 'pointer-events-none bg-gray-300 hover:bg-gray-300' : ''}`}
+              className={`bg-black text-white px-4 rounded-l-lg border-r border-white focus:outline-black hover:bg-gray-700 transition duration-300 ${parseInt(page) === 1 ? 'pointer-events-none bg-gray-300 hover:bg-gray-300' : ''}`}
             >
               &laquo;
             </button>
@@ -175,7 +175,14 @@ const Policy = () => {
                 Page <span className="text-black font-bold">{page}</span> of <span>{policyPage.documentMetadata.pageCount}</span>
               </div>
             </div>
+            {pageText.length ? 
             <div className="mt-6 text-gray-600" dangerouslySetInnerHTML={{__html: pageText}} />
+            : 
+            <div className="my-12 text-gray-600">
+              <p>This page has been intentionally left blank.</p>
+            </div>
+            }
+            
           </div>
           }
           

--- a/policy_search/parser/pdf_parser.py
+++ b/policy_search/parser/pdf_parser.py
@@ -14,79 +14,76 @@ import spacy
 from sortedcontainers import SortedKeyList
 
 # Supress fitz layout errors
-#fitz.TOOLS.mupdf_display_errors(False)
+# fitz.TOOLS.mupdf_display_errors(False)
 
 
 MIN_WORDS_SPAN = 0
 MIN_WORDS_LINE = 2
 MIN_LEN_TEXT_BLOCK = 2
-WORD_SEPARATOR = ' '
-SENTENCE_SEPARATOR = '.'
-LIND_ENDINGS = ['.', ';', '?', '!']
+WORD_SEPARATOR = " "
+SENTENCE_SEPARATOR = "."
+LIND_ENDINGS = [".", ";", "?", "!"]
 
 # Regex expressions for substitutions in an extracted text span
 regex_span_sub = [
     (
-        # regex to identify repeated non-word characters, commonly found in contents pages
-        re.compile(r'[^\w|\s]{2,}[0-9]+'), 
-        ''
+        # regex to identify repeated non-word characters, commonly found in contents
+        # pages
+        re.compile(r"[^\w|\s]{2,}[0-9]+"),
+        "",
     ),
     (
         # Replace non-breaking spaces with space character
-        re.compile(r'\xa0'),
-        ' '
+        re.compile(r"\xa0"),
+        " ",
     ),
     (
         # Replace newlines with a space character
-        re.compile(r'\n'),
-        ' '
-    )
+        re.compile(r"\n"),
+        " ",
+    ),
 ]
 
 # Regex expression for matching line endings
-regex_line_endings = re.compile(r'[?|.|!|;]\Z')
+regex_line_endings = re.compile(r"[?|.|!|;]\Z")
 
 
-class PDFParser():
+class PDFParser:
     def __init__(
-        self,
-        data_path: Path,
-        content_dir: str,
-        text_dir: str,
-        save_pdf_text: bool
+        self, data_path: Path, content_dir: str, text_dir: str, save_pdf_text: bool
     ):
         self.data_path = data_path
         self.content_path = data_path / content_dir
         self.text_path = data_path / text_dir
         self.save_pdf_text = save_pdf_text
 
-        self.nlp = spacy.load('en_core_web_sm')
+        self.nlp = spacy.load("en_core_web_sm")
 
     def apply_regex_subs(self, string):
         for regex_pattern, repl_string in regex_span_sub:
             string = re.sub(regex_pattern, repl_string, string)
-        
+
         return string
 
     def flags_decomposer(self, flags):
         """Make font flags human readable."""
-        l = []
+        _list = []
         if flags & 2 ** 0:
-            l.append("superscript")
+            _list.append("superscript")
         if flags & 2 ** 1:
-            l.append("italic")
+            _list.append("italic")
         if flags & 2 ** 2:
-            l.append("serifed")
+            _list.append("serifed")
         else:
-            l.append("sans")
+            _list.append("sans")
         if flags & 2 ** 3:
-            l.append("monospaced")
+            _list.append("monospaced")
         else:
-            l.append("proportional")
+            _list.append("proportional")
         if flags & 2 ** 4:
-            l.append("bold")
-        
-        return l
+            _list.append("bold")
+
+        return _list
 
     def block_line_spacing(self, ptb_y1):
         ly_diff = []
@@ -94,34 +91,34 @@ class PDFParser():
             for ly_ix, ly in enumerate(ptb_y1):
                 if ly_ix > 0:
                     ly_diff.append(ly[1] - ptb_y1[ly_ix - 1][1])
-            
+
             return int(sum(ly_diff) / len(ly_diff))
         else:
             return ptb_y1[0][1] - ptb_y1[0][0]
 
-
     def extract_text_blocks_on_page(self, document: fitz.Document, page_ix: int):
         # Fetch all text blocks (approximately paragraphs) from the page
-        blocks = document[page_ix].get_text('dict', flags=fitz.TEXT_DEHYPHENATE)['blocks']
+        blocks = document[page_ix].get_text("dict", flags=fitz.TEXT_DEHYPHENATE)[
+            "blocks"
+        ]
         page_text_blocks = []
         for b in blocks:
-            if b['type'] == 0:
+            if b["type"] == 0:
                 ptb = []
-                for l in b['lines']:
-                    ptb_l =[]
-                    for s in l['spans']:
-                        s_flags = self.flags_decomposer(s['flags'])
+                for line in b["lines"]:
+                    ptb_l = []
+                    for s in line["spans"]:
+                        s_flags = self.flags_decomposer(s["flags"])
                         # Ignore superscript text as is likely to be a reference
-                        if 'superscript' not in s_flags:
-                            text = self.apply_regex_subs(s['text'])
+                        if "superscript" not in s_flags:
+                            text = self.apply_regex_subs(s["text"])
                             ptb_l.append(text)
                     if len(ptb_l) > 0:
-                        ptb.append(''.join(ptb_l))
-                
+                        ptb.append("".join(ptb_l))
+
                 if len(ptb) > 0:
-                    x0, y0, x1, y1 = b['bbox']
-                    page_text_blocks.append((x0, y0, x1, y1, ' '.join(ptb), b['type']))
-                            
+                    x0, y0, x1, y1 = b["bbox"]
+                    page_text_blocks.append((x0, y0, x1, y1, " ".join(ptb), b["type"]))
 
         # Sort the textblocks in natural reading order, by sorting on y1 and x0
         page_text_blocks_sorted = SortedKeyList(page_text_blocks, key=itemgetter(0, 3))
@@ -130,17 +127,18 @@ class PDFParser():
         for x1, y1, x2, y2, text, block_type in page_text_blocks_sorted:
             if block_type == 0:
                 # Replace multiple spaces
-                text = re.sub(r'\s{2,}', ' ', text)
+                text = re.sub(r"\s{2,}", " ", text)
                 # Strip spaces off beginning and end
                 text = text.strip()
-                
-                if len(text.split(' ')) > MIN_LEN_TEXT_BLOCK:
+
+                if len(text.split(" ")) > MIN_LEN_TEXT_BLOCK:
                     extracted_text_blocks.append(text)
 
         # Concatenate extracted text blocks
         page_text = WORD_SEPARATOR.join(extracted_text_blocks)
 
-        # Occasionally, duplicated text is being extracted from the pdf - remove these cases
+        # Occasionally, duplicated text is being extracted from the pdf - remove these
+        # cases
         # TODO: remove dups
 
         # Final cleaning of page text
@@ -154,45 +152,51 @@ class PDFParser():
     def sentence_segmenter(self, page_text, min_line_length=MIN_WORDS_LINE):
         doc = self.nlp(page_text)
 
-        return [sent.text for sent in doc.sents if len(sent.text.split(WORD_SEPARATOR)) >= MIN_WORDS_LINE]
+        return [
+            sent.text
+            for sent in doc.sents
+            if len(sent.text.split(WORD_SEPARATOR)) >= MIN_WORDS_LINE
+        ]
 
-    def _convert_structure_to_string(
-        self,
-        doc_structure: List[dict]
-    ):
-        doc_string = ''
+    def _convert_structure_to_string(self, doc_structure: List[dict]):
+        doc_string = ""
         for page_ix in doc_structure.keys():
             for sent in doc_structure[page_ix]:
-                sent = sent + '\n'
+                sent = sent + "\n"
                 doc_string += sent
 
         return doc_string
 
     def extract_text(
-        self, 
+        self,
         pdf_filename: Path,
-        extract_type: str='structure',
+        extract_type: str = "structure",
     ):
-        assert(extract_type in ['structure', 'string'])
+        assert extract_type in ["structure", "string"]
 
         extract_structure = False
-        if extract_type == 'structure':
+        if extract_type == "structure":
             extract_structure = True
 
         doc_structure = {}
 
         try:
             doc = self.open(pdf_filename)
-            
+
             for doc_page_ix in range(0, doc.page_count):
                 page_text = self.extract_text_blocks_on_page(doc, doc_page_ix)
 
-                # If we extracted text, then add to doc structure
+                # If we extracted text, then add to doc structure.
+                # Page index starts at 1.
                 if len(page_text) > 0:
-                    doc_structure[doc_page_ix] = [sent.strip() for sent in self.sentence_segmenter(page_text)]
+                    doc_structure[doc_page_ix + 1] = [
+                        sent.strip() for sent in self.sentence_segmenter(page_text)
+                    ]
+                else:
+                    doc_structure[doc_page_ix + 1] = []
 
             doc.close()
-        except Exception as e:
+        except Exception:
             return doc_structure, None
 
         text_filename = None
@@ -205,30 +209,31 @@ class PDFParser():
             return doc_structure, text_filename
 
     def save_text(self, doc_structure, pdf_filename):
-        text_filename = f'{pdf_filename.stem}.txt'
+        text_filename = f"{pdf_filename.stem}.txt"
         text_path = self.text_path / text_filename
-        with open(text_path, 'wt') as text_f:
+        with open(text_path, "wt") as text_f:
             for page_ix in doc_structure:
                 for sent in doc_structure[page_ix]:
-                    text_f.write(sent + '\n')
+                    text_f.write(sent + "\n")
 
         return text_filename
 
     def process_pdfs(
-        self, 
+        self,
         doc_fetcher: CSVDocumentSourceFetcher,
-        save_text: bool=False,
-        yield_text: bool=True,
+        save_text: bool = False,
+        yield_text: bool = True,
     ):
-        content_filename_col = 'policy_content_file'
+        content_filename_col = "policy_content_file"
         docs = doc_fetcher.get_docs()
 
         # Iterate over documents, generate page images and perform layout analysis
         for doc in docs:
             pdf_filename = Path(doc[content_filename_col])
 
-            doc_text = self.extract_text(pdf_filename, )
+            doc_text = self.extract_text(
+                pdf_filename,
+            )
 
             if yield_text:
                 yield doc_text
-


### PR DESCRIPTION
Updated PDF parser so that:
* page indexes start at 1
* when there is no text on a page, an empty array is returned, rather than a document being missing for that page.

Testing:
* In Elasticsearch, pages now start at 1 for each document.
* Calling `http://localhost:8001/policies/3/text/?page=2` returns an empty array for the `pageText` field. The corresponding page of the PDF is blank.

Also formatted the file with `black` and resolved some `flake8` errors. (I will run formatting on linting on the whole code base, after the prototype 🙂). **Actual changes are on line 191**

Related to https://github.com/climatepolicyradar/cpr-issues/issues/110

@chrisaballard @eurolife please could you review?