### PR TITLE
Feat 46 resolve opensearch bulk load errors

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -115,7 +115,7 @@ def load(
     )
 
     # Initialise document processor, add callback objects and process text
-    doc_processor = DocumentProcessor(doc_fetcher, doc_parser, n_batch=10)
+    doc_processor = DocumentProcessor(doc_fetcher, doc_parser, n_batch=50)
     doc_processor.add_callback(dynamodb_table)
     doc_processor.add_callback(search_index)
     doc_processor.process_text()

--- a/policy_search/pipeline/opensearch.py
+++ b/policy_search/pipeline/opensearch.py
@@ -147,7 +147,7 @@ class OpenSearchIndex(BaseCallback):
                 max_retries=5,
                 chunk_size=1,
                 initial_backoff=5,
-                max_backoff=500,
+                max_backoff=200,
             )
 
             successes = 0

--- a/policy_search/pipeline/opensearch.py
+++ b/policy_search/pipeline/opensearch.py
@@ -3,9 +3,6 @@
 
 
 from typing import List, Optional
-from opensearchpy.client import logger
-from opensearchpy.exceptions import TransportError
-from urllib3.exceptions import ReadTimeoutError
 
 from opensearchpy import OpenSearch, helpers
 
@@ -140,6 +137,7 @@ class OpenSearchIndex(BaseCallback):
             self._connect_to_elasticsearch()
 
         try:
+            self.es.indices.put_settings({"index": {"refresh_interval": -1}})
             bulk_loader = helpers.streaming_bulk(
                 client=self.es,
                 index=self.index_name,
@@ -149,7 +147,7 @@ class OpenSearchIndex(BaseCallback):
                 max_retries=5,
                 chunk_size=1,
                 initial_backoff=5,
-                max_backoff=60
+                max_backoff=500,
             )
 
             successes = 0
@@ -160,13 +158,14 @@ class OpenSearchIndex(BaseCallback):
                     errs.append(action)
 
                 successes += ok
-        except ReadTimeoutError as e:
-            logger.error("Read timeout error occured when processing batch, igoring batch")
-        except TransportError as e:
-            logger.error("Transport error occured when processing batch, ignoring batch: " + str(e))
+        # except ReadTimeoutError as e:
+        #     logger.error("Read timeout error occured when processing batch, igoring batch")
+        # except TransportError as e:
+        #     logger.error("Transport error occured when processing batch, ignoring batch: " + str(e))
         finally:
             # Clear in memory store of documents to load ready for next batch
             self._docs_to_load = []
+            self.es.indices.put_settings({"index": {"refresh_interval": "1s"}})
 
     def get_doc_by_id(
         self,

--- a/policy_search/pipeline/opensearch.py
+++ b/policy_search/pipeline/opensearch.py
@@ -137,7 +137,6 @@ class OpenSearchIndex(BaseCallback):
             self._connect_to_elasticsearch()
 
         try:
-            self.es.indices.put_settings({"index": {"refresh_interval": -1}})
             bulk_loader = helpers.streaming_bulk(
                 client=self.es,
                 index=self.index_name,
@@ -165,7 +164,6 @@ class OpenSearchIndex(BaseCallback):
         finally:
             # Clear in memory store of documents to load ready for next batch
             self._docs_to_load = []
-            self.es.indices.put_settings({"index": {"refresh_interval": "1s"}})
 
     def get_doc_by_id(
         self,


### PR DESCRIPTION
On an `r6g.4xlarge.search` instance (16 vCPU; 128GB RAM; $1.572/hr), I managed to get the load to complete without errors, in 51 minutes. 

I think this is a good solution for now as the extra cost is negligible given the load time, and it requires minimal code changes.

I made the following changes:

* After the following error, I increased the EBS size from 30GB to 40GB. `opensearchpy.helpers.errors.BulkIndexError: ('1 document(s) failed to index.', [{'index': {'_index': 'policies', '_type': '_doc', '_id': '1352_page249', 'status': 403, 'error': {'type': 'cluster_block_exception', 'reason': 'index [policies] blocked by: [TOO_MANY_REQUESTS/12/disk usage exceeded flood-stage watermark, index has read-only-allow-delete block, FORBIDDEN/8/index write (api)];'},`. 
* I commented out skipping batches when there is a BulkIndexError or TransportError. Note from the above example that the BulkIndexError was caused by lack of disk space rather than RAM - I'm not sure what effect this code would have had in that instance, but we wouldn't have caught that the error was disk-related rather than RAM-related.
* Increased `n_batch` parameter in `DocumentProcessor` from 10 to 50 in the load.
* Increased `max_backoff` in the bulk loader from 60 to 200, after noticing that processing occurs on my local opensearch instance sometimes which locks me out of it for 2-3 minutes.

closes #46 