### PR TITLE
Add API path to return multiple policies by id (#113)

### DIFF
--- a/api.py
+++ b/api.py
@@ -62,9 +62,11 @@ async def read_policies(
     return policy_table.scan(start, limit)
 
 
-async def read_policies_by_ids(ids: List[int]):
+@app.get("/policies/multiple/", response_model=List[Policy])
+async def read_policies_by_ids(id: List[int] = Query([])):
     """Get policy metadata from a list of IDs"""
-    return [policy_table.get_document(_id) for _id in ids]
+
+    return [policy_table.get_document(_id) for _id in id]
 
 
 @app.get("/policies/search/", response_model=PolicySearchResponse)


### PR DESCRIPTION
Added the path `/policies/multiple` which takes multiple `id` query string values and returns a list of document metadata corresponding to each of these IDs.

### Example request

`GET http://localhost:8001/policies/multiple/?id=1&id=10`

### Example response

``` json
[
    {
        "policyId": 1,
        "policyName": "National Forest Policy",
        "countryCode": "SUR",
        "language": "en",
        "sourceName": "cclw",
        "sourcePolicyId": 10046,
        "url": "https://climate-laws.org/rails/active_storage/blobs/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBa2NHIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--9acd30f99e1993ebc109c3791000bae3be9a3d40/f",
        "policyType": "executive",
        "policyTxtFile": null
    },
    {
        "policyId": 10,
        "policyName": "Low-Carbon Development Strategy of the Slovak Republic until 2030 with a View to 2050",
        "countryCode": "SVK",
        "language": "en",
        "sourceName": "cclw",
        "sourcePolicyId": 10029,
        "url": "https://minzp.sk/files/oblasti/politika-zmeny-klimy/ets/lts-sk-eng.pdf",
        "policyType": "executive",
        "policyTxtFile": null
    }
]

```

* @eurolife - does this look ok for you?
* @chrisaballard - how does this look? I chose `/policies/multiple` as we already have `/policies/{policy_id}`. I guess at some point we could move toward `/policies/?id=1&id=2` which can take either one or multiple IDs?