### PR TITLE
Fix policy name mapping (#67)

### DIFF
--- a/api.py
+++ b/api.py
@@ -83,7 +83,10 @@ async def search_policies(
 
     if query is None:
         titles_ids_alphabetical = es.get_docs_sorted_alphabetically(
-            "policy_name", asc=True, num_docs=start + limit, keyword_filters=kwd_filters
+            "policy_name.normalized",
+            asc=True,
+            num_docs=start + limit,
+            keyword_filters=kwd_filters,
         )
         ids = [item["policy_id"] for item in titles_ids_alphabetical]
         documents = await read_policies_by_ids(ids)

--- a/policy_search/pipeline/opensearch.py
+++ b/policy_search/pipeline/opensearch.py
@@ -91,8 +91,13 @@ class OpenSearchIndex(BaseCallback):
                         },
                     },
                     "policy_name": {
-                        "type": "keyword",
-                        "normalizer": "lowercase_asciifold",
+                        "type": "text",
+                        "fields": {
+                            "normalized": {
+                                "type": "keyword",
+                                "normalizer": "lowercase_asciifold",
+                            }
+                        },
                     },
                 }
             },


### PR DESCRIPTION
Converted field `policy_name` to a `text` field, and created a `policy_name.normalized` field we can use for alphabetical sorting on title. Swapped alphabetical sorting to use the new normalized field.

closes #67 