### PR TITLE
Feats 70 & 71 - opensearch query changes for demo

### DIFF
--- a/api.py
+++ b/api.py
@@ -102,6 +102,8 @@ async def search_policies(
     if keyword:
         kwd_filters["keywords.keyword"] = keyword
 
+    kwd_filters["source_name.keyword"] = ["cclw"]
+
     year_range = None
     if any([year_start, year_end]):
         year_range = (year_start, year_end)

--- a/api.py
+++ b/api.py
@@ -102,6 +102,7 @@ async def search_policies(
     if keyword:
         kwd_filters["keywords.keyword"] = keyword
 
+    # TODO: this is a short-term fix to filter searches down to CCLW data only.
     kwd_filters["source_name.keyword"] = ["cclw"]
 
     year_range = None

--- a/api.py
+++ b/api.py
@@ -86,7 +86,7 @@ async def search_policies(
     "Search for policies given a specified query"
 
     kwd_filters = {}
-    
+
     if geography:
         kwd_filters["country_code.keyword"] = geography
     if sector:
@@ -98,7 +98,7 @@ async def search_policies(
     if hazard:
         kwd_filters["hazards.keyword"] = hazard
     if document_type:
-        kwd_filters["document_types.keyword"] = document_type        
+        kwd_filters["document_types.keyword"] = document_type
     if keyword:
         kwd_filters["keywords.keyword"] = keyword
 
@@ -107,9 +107,9 @@ async def search_policies(
         year_range = (year_start, year_end)
 
     if query is None:
-        titles_ids_alphabetical = es.get_docs_sorted_alphabetically(
-            "policy_name.normalized",
-            asc=True,
+        titles_ids_alphabetical = es.get_docs_sorted(
+            "policy_date",
+            asc=False,
             num_docs=start + limit,
             keyword_filters=kwd_filters,
             year_range=year_range,
@@ -135,7 +135,7 @@ async def search_policies(
         query_emb,
         limit=start + limit,
         keyword_filters=kwd_filters,
-        year_range=year_range
+        year_range=year_range,
     )
 
     results_by_doc = search_result["aggregations"]["top_docs"]["buckets"]

--- a/policy_search/pipeline/opensearch.py
+++ b/policy_search/pipeline/opensearch.py
@@ -99,10 +99,7 @@ class OpenSearchIndex(BaseCallback):
                             }
                         },
                     },
-                    "policy_date": {
-                        "type": "date",
-                        "format": "dd/MM/yyyy"
-                    }
+                    "policy_date": {"type": "date", "format": "dd/MM/yyyy"},
                 }
             },
         }
@@ -271,7 +268,9 @@ class OpenSearchIndex(BaseCallback):
             if "filter" not in es_query["query"]["bool"]:
                 es_query["query"]["bool"]["filter"] = []
 
-            es_query["query"]["bool"]["filter"].append(self._year_range_filter(year_range))
+            es_query["query"]["bool"]["filter"].append(
+                self._year_range_filter(year_range)
+            )
 
         return self.es.search(body=es_query, index=self.index_name, request_timeout=30)
 
@@ -287,14 +286,11 @@ class OpenSearchIndex(BaseCallback):
         if end_date is not None:
             policy_year_conditions["lte"] = end_date
 
-        range_filter = {
-            "range": {}
-        }
+        range_filter = {"range": {}}
 
         range_filter["range"]["policy_date"] = policy_year_conditions
-        
-        return range_filter
 
+        return range_filter
 
     def get_page_count_for_doc(self, policy_id: int) -> int:
         """Return the total number of pages in the elastic search index for a given document"""
@@ -356,7 +352,7 @@ class OpenSearchIndex(BaseCallback):
             "source_name": doc.source_name,
         }
 
-    def get_docs_sorted_alphabetically(
+    def get_docs_sorted(
         self,
         field_name: str,
         asc: bool = True,
@@ -367,7 +363,7 @@ class OpenSearchIndex(BaseCallback):
         """Get document IDs (`policy_id`) and field values, sorted by the values of `field_name`.
 
         Args:
-            field_name (str): name of a text field, in dot notation
+            field_name (str): name of a field, in dot notation. A `_term` sort will be used on this field.
             asc (bool, optional): sort the results ascending (/descending). Defaults to True.
             num_docs (int, optional): the number of documents to return
             keyword_filters (dict, optional): each key is a field to be filtered, and each value is a list of strings to filter on.
@@ -393,7 +389,7 @@ class OpenSearchIndex(BaseCallback):
             query["query"] = {}
             query["query"]["bool"] = {}
             query["query"]["bool"]["filter"] = []
-        
+
         if keyword_filters:
             terms_clauses = []
 
@@ -403,9 +399,7 @@ class OpenSearchIndex(BaseCallback):
             query["query"]["bool"]["filter"] = terms_clauses
 
         if year_range is not None:
-            query["query"]["bool"]["filter"].append(
-                self._year_range_filter(year_range)
-            )
+            query["query"]["bool"]["filter"].append(self._year_range_filter(year_range))
 
         query_result = self.es.search(body=query, index=self.index_name)
 


### PR DESCRIPTION
* Filtered searches to cclw data by adding `["source_name.keyword"] = ["cclw"]` to the `search_policies` method in the API
* `pipeline.opensearch.OpenSearchIndex.get_docs_sorted_alphabetically` already contained the functionality to sort a field and aggregate it by document. I renamed it to `get_docs_sorted` and applied it to the *policy_date* field in descending order.

Tested both changes on a local subset of data and they look ok.

closes #70; closes #71