### PR TITLE
Bugfix #113 error requesting missing ids

### DIFF
--- a/api.py
+++ b/api.py
@@ -13,6 +13,9 @@ from policy_search.pipeline.models.policy import PolicyPageText, PolicySearchRes
 from policy_search.pipeline.semantic_search import SBERTEncoder
 from temp_geographies.load_geographies_data import Geography, load_geographies_data
 from schema.schema_helpers import get_schema_dict_from_path, SchemaTopLevel
+from policy_search.logging import get_logger
+
+logger = get_logger("api")
 
 POLICIES_TABLE = "Policies"
 
@@ -65,7 +68,16 @@ async def read_policies(
 async def read_policies_by_ids(id: List[int] = Query([])):
     """Get policy metadata from a list of IDs"""
 
-    return [policy_table.get_document(_id) for _id in id]
+    policies = []
+
+    for _id in id:
+        policy = policy_table.get_document(_id)
+        if policy is not None:
+            policies.append(policy)
+        else:
+            logger.error(f"Policy {_id} missing in call to /policies/multiple")
+
+    return policies
 
 
 @app.get("/policies/search/", response_model=PolicySearchResponse)

--- a/policy_search/pipeline/dynamo.py
+++ b/policy_search/pipeline/dynamo.py
@@ -152,12 +152,13 @@ class PolicyDynamoDBTable(DynamoDBTable):
 
         return table
 
-    def get_document(self, key):
-        policy = Policy(
-            **super().get_document(key)
-        )
+    def get_document(self, key):        
+        policy_dict = super().get_document(key)
 
-        return policy
+        if len(policy_dict) > 0:
+            policy = Policy(**policy_dict)
+
+            return policy
 
     def scan(self, start: int=None, limit: int=100):
         items, last_key, count = super().scan(start, limit)


### PR DESCRIPTION
Fixed issue detailed in 113 where passing missing ids to the `/policies/multiple` endpoint raised an internal server error. The missing ids are now ignored in the response. Any missing ids are output to the terminal using the logger for debug purposes.