### PR TITLE
Bug 72 - issue with query response time

### DIFF
--- a/api.py
+++ b/api.py
@@ -156,7 +156,7 @@ async def search_policies(
         year_range=year_range,
     )
 
-    results_by_doc = search_result["aggregations"]["top_docs"]["buckets"]
+    results_by_doc = search_result["aggregations"]["sample"]["top_docs"]["buckets"]
 
     query_results_by_doc = []
 

--- a/policy_search/pipeline/opensearch.py
+++ b/policy_search/pipeline/opensearch.py
@@ -194,7 +194,7 @@ class OpenSearchIndex(BaseCallback):
         max_pages_per_doc: Optional[int] = 10,
         year_range: Tuple[int, int] = None,
         max_passages_per_page: Optional[int] = 5,
-        sampler_top_docs_to_filter_per_shard: Optional[int] = 150,
+        sampler_top_docs_to_filter_per_shard: Optional[int] = 120,
     ) -> List[dict]:
         """
         Search for `query`, starting at result `start` and returning up to `limit` results.

--- a/policy_search/pipeline/opensearch.py
+++ b/policy_search/pipeline/opensearch.py
@@ -215,7 +215,7 @@ class OpenSearchIndex(BaseCallback):
         BOOST_TITLE_MATCH_PHRASE = 1.2
 
         es_query = {
-            "_source": {"excludes": ["text.embedding"]},
+            "size": 0,
             "query": {
                 "bool": {
                     "must": [

--- a/policy_search/pipeline/opensearch.py
+++ b/policy_search/pipeline/opensearch.py
@@ -321,7 +321,12 @@ class OpenSearchIndex(BaseCallback):
                 self._year_range_filter(year_range)
             )
 
-        return self.es.search(body=es_query, index=self.index_name, request_timeout=30)
+        return self.es.search(
+            body=es_query,
+            index=self.index_name,
+            request_timeout=30,
+            preference="prototype_user",
+        )
 
     def _year_range_filter(self, year_range: Tuple[int, int]):
         """Returns an opensearch filter for year range"""

--- a/policy_search/pipeline/opensearch.py
+++ b/policy_search/pipeline/opensearch.py
@@ -191,10 +191,10 @@ class OpenSearchIndex(BaseCallback):
         limit: Optional[int] = None,
         # start: Optional[int] = 0,
         keyword_filters: Optional[dict] = None,
-        max_pages_per_doc: Optional[int] = 20,
+        max_pages_per_doc: Optional[int] = 10,
         year_range: Tuple[int, int] = None,
         max_passages_per_page: Optional[int] = 5,
-        sampler_top_docs_to_filter_per_shard: Optional[int] = 100,
+        sampler_top_docs_to_filter_per_shard: Optional[int] = 150,
     ) -> List[dict]:
         """
         Search for `query`, starting at result `start` and returning up to `limit` results.


### PR DESCRIPTION
The issue was caused because the `aggregation` step was trying to roll up passages to each of the ~1.7M docs in the corpus. `policy_id` is a high cardinality field (there are lots of unique values), so [this operation is slow](https://www.elastic.co/blog/improving-the-performance-of-high-cardinality-terms-aggregations-in-elasticsearch).

I've added a [sampler](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-sampler-aggregation.html) to limit the number of docs per shard that are considered for aggregation.

In my tests this reduced average query time from ~8 seconds to <4 seconds. We can tweak this parameter further once the instance is deployed if we need.

However, this sampler means that the number of passages per page (thus pages per document) is filtered to the top few per document. This means that when a filter, e.g. on geography, is applied after performing a search, the number of passages/pages returned for each document can increase, as the sampler is acting on fewer documents. To minimise the negative UX impact of this for now, I've:

* reduced the maximum number of pages shown per document from 20 to 10
* raised #77 to update the UI to indicate this change

**Updates**

* In line with [guidance](https://www.elastic.co/guide/en/elasticsearch/reference/current/tune-for-search-speed.html#preference-cache-optimization), I've also set a fixed `preference` string, which can lead to better use of the Opensearch cache. 
* I've also added `size: 0`to the aggregation query, as we are only interested in `aggregation` results.

closes #72 