### PR TITLE
Feat 87 - Map top level instrument and sectors to lower level in policy search

### DIFF
--- a/schema/instruments.csv
+++ b/schema/instruments.csv
@@ -56,7 +56,7 @@ DIRECT INVESTMENT,Finance,Loan
 DIRECT INVESTMENT,Finance,Low-carbon finance
 DIRECT INVESTMENT,Ecosystem restoration and nature-based solutions,Ecosystem restoration
 DIRECT INVESTMENT,Ecosystem restoration and nature-based solutions,Nature-based solutions
-DIRECT INVESMENT,Insurance,Insurance
+DIRECT INVESTMENT,Insurance,Insurance
 GOVERNANCE AND PLANNING,Governance and planning (general),Governance
 GOVERNANCE AND PLANNING,Governance and planning (general),Planning
 GOVERNANCE AND PLANNING,"Monitoring, reporting, verification",Monitoring

--- a/schema/instruments.yml
+++ b/schema/instruments.yml
@@ -47,13 +47,6 @@
     - stakeholder engagement
     - structures
 - id: 1
-  name: DIRECT INVESMENT
-  levels:
-  - id: 0
-    name: Insurance
-    keywords:
-    - insurance
-- id: 2
   name: DIRECT INVESTMENT
   levels:
   - id: 0
@@ -87,12 +80,16 @@
     - resilience funding
     - social safety nets
   - id: 3
+    name: Insurance
+    keywords:
+    - insurance
+  - id: 4
     name: Public goods
     keywords:
     - commons
     - early warning systems
     - public goods
-- id: 3
+- id: 2
   name: GOVERNANCE AND PLANNING
   levels:
   - id: 0
@@ -162,7 +159,7 @@
     - duty to set target
     - legally binding target
     - target
-- id: 4
+- id: 3
   name: INCENTIVES
   levels:
   - id: 0
@@ -198,7 +195,7 @@
     - emissions trading
     - market-based instruments
     - permits
-- id: 5
+- id: 4
   name: REGULATION
   levels:
   - id: 0

--- a/schema/schema_helpers.py
+++ b/schema/schema_helpers.py
@@ -58,6 +58,45 @@ class Schema:
 
         return data_no_keywords
 
+    def _leaf_mapping(self):
+        """Return a dictionary mapping a top level schema node to corresponding lower levels"""
+        
+        mapping = {}
+        for level in self.to_dict():
+            mapping[level["name"]] = [sublevel["name"] for sublevel in level["levels"]]
+
+        return mapping
+
+    def _get_leaf_levels(self):
+        leaf_levels = []
+        for levels in self._leaf_mapping().values():
+            leaf_levels += levels
+
+        return leaf_levels
+    
+    def _get_leaf_levels_for_node(self, name):
+        """For a given top level node, return a list of lower levels assigned to that node"""
+
+        # Lookup level in dictionary, unless a leaf level has been passed
+        if name not in self._get_leaf_levels():
+            # return the leaf levels assigned to the top level
+            return self._leaf_mapping().get(name, [])
+
+        # Otherwise, if this is a leaf level, return the leaf level as there are no further leaf levels
+        return [name]
+
+    def get_leaf_levels(self, levels_list: List[str]):
+        """For a given schema, remaps a list of top levels to a list of leaf levels in the schema"""
+
+        schema_leaf_levels = []
+        for level_name in levels_list:
+            schema_leaf_levels += self._get_leaf_levels_for_node(level_name)
+
+        return schema_leaf_levels
+
+
+
+
 
 def get_schema_dict_from_path(path: Path) -> dict:
     schema = Schema.from_yaml_path(path)


### PR DESCRIPTION
When calling `/policies/search` and passing in a list of instrument or sectors as query string parameters, the provided values are now mapped to the leaf level nodes on the instrument and sector schema.

This has been done because in the user interface the user is only able to choose top level instrument and sector nodes. However, the lowest level has been stored against each document in the OpenSearch index.

If a lower level node is passed in the api, then the value will be returned "as is" and not mapped.