### PR TITLE
PassageParser starts page numbers at 1 (#81)

### DIFF
--- a/policy_search/parser/passage_parser.py
+++ b/policy_search/parser/passage_parser.py
@@ -71,7 +71,7 @@ class PassageParser(BaseParser):
 
             doc_structure = defaultdict(list)
             for page_id, passage in policy_passages.iterrows():
-                doc_structure[page_id].append(
+                doc_structure[page_id + 1].append(
                     {
                         "text_id": passage["text_id"],
                         "text": passage["text"],


### PR DESCRIPTION
Reasons for this bug are as highlighted in the comments of #81:

* In https://github.com/climatepolicyradar/cpr-issues/issues/110, changes were made to the PDF parser so that document page numbers started at 1 (from 0). This made sense as it meant that page numbers didn't have to be incremented in the UI or API.
* When switching to the `PassageParser`, pages were set to index at 0. This meant that the UI was one page ahead when showing the full text of pages, even though they were available in the UI and through Opensearch.

To fix this, I made a change so that the `doc_structure` returned by `PassageParser.extract_text()` starts page numbers at 1.

This means that a reload of the data will need to be done.

closes #81 